### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ composer.lock
 .idea
 .project
 .settings
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: php
 php:
   - 7.1
   - 7.2
-
+  - 7.3
+  - 7.4
 
 before_script:
   - composer self-update
-  - composer --dev install
+  - composer install
 
 script:
   - php ./vendor/bin/phpunit
-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,4 +6,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/ArrayReaderTest.php
+++ b/tests/ArrayReaderTest.php
@@ -27,13 +27,13 @@ class ArrayReaderTest extends TestCase
     public function is_integer_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 1
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(1, $arrayReader->integerValue('hash.with.nested'));
@@ -45,13 +45,13 @@ class ArrayReaderTest extends TestCase
     public function is_string_converted_to_integer_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => '1'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(1, $arrayReader->integerValue('hash.with.nested'));
@@ -63,13 +63,13 @@ class ArrayReaderTest extends TestCase
     public function is_default_integer_returned_when_path_not_exists()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => '1'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(2, $arrayReader->integerValue('hash.with.unknown', 2));
@@ -81,13 +81,13 @@ class ArrayReaderTest extends TestCase
     public function is_float_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 1.0
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(1.0, $arrayReader->floatValue('hash.with.nested'));
@@ -99,13 +99,13 @@ class ArrayReaderTest extends TestCase
     public function is_string_converted_to_float_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => '1.0'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(1.0, $arrayReader->floatValue('hash.with.nested'));
@@ -117,13 +117,13 @@ class ArrayReaderTest extends TestCase
     public function is_default_float_returned_when_path_not_exists()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => '1.0'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame(2.1, $arrayReader->floatValue('hash.with.unknown', 2.1));
@@ -135,13 +135,13 @@ class ArrayReaderTest extends TestCase
     public function is_boolean_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => true
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertTrue($arrayReader->booleanValue('hash.with.nested'));
@@ -153,13 +153,13 @@ class ArrayReaderTest extends TestCase
     public function is_string_converted_to_boolean_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => '1'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertTrue($arrayReader->booleanValue('hash.with.nested'));
@@ -171,13 +171,13 @@ class ArrayReaderTest extends TestCase
     public function is_default_boolean_returned_when_path_not_exists()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => true
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertFalse($arrayReader->booleanValue('hash.with.unknown'));
@@ -189,13 +189,13 @@ class ArrayReaderTest extends TestCase
     public function is_string_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 'value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame('value', $arrayReader->stringValue('hash.with.nested'));
@@ -207,13 +207,13 @@ class ArrayReaderTest extends TestCase
     public function is_float_converted_to_string_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 1.1
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame('1.1', $arrayReader->stringValue('hash.with.nested'));
@@ -225,13 +225,13 @@ class ArrayReaderTest extends TestCase
     public function is_default_string_returned_when_path_not_exists()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 'value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame('default', $arrayReader->stringValue('hash.with.unknown', 'default'));
@@ -243,18 +243,18 @@ class ArrayReaderTest extends TestCase
     public function is_array_value()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
-                        'nested' => array(
+            [
+                'hash' => [
+                    'with' => [
+                        'nested' => [
                             'value'
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
 
-        $this->assertSame(array('value'), $arrayReader->arrayValue('hash.with.nested'));
+        $this->assertSame(['value'], $arrayReader->arrayValue('hash.with.nested'));
     }
 
     /**
@@ -266,16 +266,16 @@ class ArrayReaderTest extends TestCase
         $object->param = 'value';
 
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => $object
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
-        $this->assertSame(array('param' => 'value'), $arrayReader->arrayValue('hash.with.nested'));
+        $this->assertSame(['param' => 'value'], $arrayReader->arrayValue('hash.with.nested'));
     }
 
     /**
@@ -287,16 +287,16 @@ class ArrayReaderTest extends TestCase
         $object->param = 'value';
 
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 'scalar value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
-        $this->assertSame(array('scalar value'), $arrayReader->arrayValue('hash.with.nested'));
+        $this->assertSame(['scalar value'], $arrayReader->arrayValue('hash.with.nested'));
     }
 
     /**
@@ -305,16 +305,16 @@ class ArrayReaderTest extends TestCase
     public function is_default_array_returned_when_path_not_exists()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 'value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
-        $this->assertSame(array('default'), $arrayReader->arrayValue('hash.with.unknown', array('default')));
+        $this->assertSame(['default'], $arrayReader->arrayValue('hash.with.unknown', ['default']));
     }
 
     /**
@@ -323,22 +323,22 @@ class ArrayReaderTest extends TestCase
     public function is_original_array_returned()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => 'value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
-        $check = array(
-            'hash' => array(
-                'with' => array(
+        $check = [
+            'hash' => [
+                'with' => [
                     'nested' => 'value'
-                )
-            )
-        );
+                ]
+            ]
+        ];
 
         $this->assertEquals($check, $arrayReader->toArray());
     }
@@ -349,13 +349,13 @@ class ArrayReaderTest extends TestCase
     public function is_escaped_dot_ignored_in_path_detection()
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with.dot.key' => array(
+            [
+                'hash' => [
+                    'with.dot.key' => [
                         'nested' => 'value'
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame('value', $arrayReader->stringValue('hash.with\.dot\.key.nested', 'default'));
@@ -368,13 +368,13 @@ class ArrayReaderTest extends TestCase
     public function is_mixed_value($value)
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => $value
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $this->assertSame($value, $arrayReader->mixedValue('hash.with.nested'));
@@ -387,16 +387,16 @@ class ArrayReaderTest extends TestCase
     public function is_default_mixed_returned_when_path_not_exists($value)
     {
         $arrayReader = new ArrayReader(
-            array(
-                'hash' => array(
-                    'with' => array(
+            [
+                'hash' => [
+                    'with' => [
                         'nested' => $value
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
-        $this->assertSame(null, $arrayReader->mixedValue('hash.with.unknown', null));
+        $this->assertNull($arrayReader->mixedValue('hash.with.unknown', null));
     }
 
     public function provideForMixedTest()


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` version tests during Travis CI build.
- Let `.phpunit.result.cache` file not under Git version control and let this file be in `.gitignore` file.
- To be consistency, using the short array syntax for all PHP codes.
- Using the `assertNull` assertion to assert expected value is `null`.
- Add white filter lists to evaluate code covers.